### PR TITLE
Fix error invalid literal for int() with base 16 

### DIFF
--- a/Enum4LinuxPy.py
+++ b/Enum4LinuxPy.py
@@ -506,7 +506,7 @@ def enum_groups(args):
             # GET GROUP NAME, MEMBERS & RID
 
             if not args.nomemberlist:
-                groupdata = re.findall(r"(\[[\w\s\-\_\{\}\.\$]+\])", output, re.I);
+                groupdata = re.findall(r"(\[[\w\s\-\_\{\}\.\$\#]+\])", output, re.I);
 
                 for data in range(0, len(groupdata), 2):
                     print("[+] Information for group '{}' (RID {}):".format(groupdata[data].strip("[]"),


### PR DESCRIPTION
Fix error `invalid literal for int() with base 16` when a group name contains the char '#' => broken regex 

This PR add the `#` char to the the regex

**before**
![image](https://user-images.githubusercontent.com/5891788/72348013-b1fa5e80-36d9-11ea-9d53-e556f54e8c92.png)

**after**
![image](https://user-images.githubusercontent.com/5891788/72348032-c0e11100-36d9-11ea-946c-4b9c0f9fe805.png)

